### PR TITLE
feat: modelo SemanaForecast con validaciones y total semanal

### DIFF
--- a/forecast_app/admin.py
+++ b/forecast_app/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from .models import SemanaForecast
+
+@admin.register(SemanaForecast)
+class SemanaForecastAdmin(admin.ModelAdmin):
+    list_display = ('fecha_lunes', 'lunes', 'martes', 'miercoles', 'jueves', 'viernes', 'sabado', 'domingo', 'total')

--- a/forecast_app/models.py
+++ b/forecast_app/models.py
@@ -1,0 +1,25 @@
+from django.db import models
+from django.core.exceptions import ValidationError
+
+# Create your models here.
+
+class SemanaForecast(models.Model):
+    fecha_lunes = models.DateField()
+    lunes = models.PositiveIntegerField()
+    martes = models.PositiveIntegerField()
+    miercoles = models.PositiveIntegerField()
+    jueves = models.PositiveIntegerField()
+    viernes = models.PositiveIntegerField()
+    sabado = models.PositiveIntegerField()
+    domingo = models.PositiveIntegerField()
+    
+    def clean(self):
+        if self.fecha_lunes.weekday() != 0:
+            raise ValidationError("La fecha debe ser un lunes.")
+    
+    @property
+    def total(self):
+        return (
+            self.lunes + self.martes + self.miercoles +
+            self.jueves + self.viernes + self.sabado + self.domingo
+        )


### PR DESCRIPTION
Esta PR implementa el modelo base SemanaForecast con:
- Campo de fecha que valida que sea lunes
- Campos diarios de forecast (lunes a domingo)
- Cálculo del total semanal como propiedad
- Registro del modelo en el Admin con list_display